### PR TITLE
Critical fix: Exclude form-handler.html from edge function routing

### DIFF
--- a/netlify/edge-functions/detect-language.js
+++ b/netlify/edge-functions/detect-language.js
@@ -3,9 +3,9 @@ export default async (request, context) => {
     const pathname = url.pathname;
     
     // Skip processing for static assets and special paths
-    const staticExtensions = ['.css', '.js', '.mjs', '.jsx', '.ts', '.tsx', '.json', '.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico', '.woff', '.woff2', '.ttf', '.otf', '.map'];
+    const staticExtensions = ['.css', '.js', '.mjs', '.jsx', '.ts', '.tsx', '.json', '.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico', '.woff', '.woff2', '.ttf', '.otf', '.map', '.html'];
     const specialPaths = ['/_astro/', '/node_modules/', '/@vite/', '/@fs/', '/src/'];
-    const excludedPages = ['/success', '/about', '/blog', '/contact'];
+    const excludedPages = ['/success', '/about', '/blog', '/contact', '/form-handler.html'];
     
     const hasStaticExtension = staticExtensions.some(ext => pathname.endsWith(ext));
     const isSpecialPath = specialPaths.some(path => pathname.includes(path));


### PR DESCRIPTION
This allows Netlify to properly detect forms during build process