### PR TITLE
Fix forms to submit to current page URL

### DIFF
--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -207,8 +207,8 @@ const t = useTranslations(lang);
             if (submitBtn) submitBtn.setAttribute('disabled', 'true');
             
             try {
-                // Submit exactly like a real HTML form would
-                const response = await fetch('/', {
+                // Submit to the current page where the form exists
+                const response = await fetch(window.location.href, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                     body: formBody.toString()

--- a/src/components/WaitlistForm.astro
+++ b/src/components/WaitlistForm.astro
@@ -371,8 +371,8 @@ const texts = formTranslations[lang] || formTranslations.en;
         if (submitBtn) submitBtn.setAttribute('disabled', 'true');
         
         try {
-            // Submit exactly like a real HTML form would
-            const response = await fetch('/', {
+            // Submit to the current page where the form exists
+            const response = await fetch(window.location.href, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                 body: formBody.toString()


### PR DESCRIPTION
- Changed both WaitlistForm and ContactForm to submit to window.location.href
- Forms now submit to /en/ or /tr/ where they exist, not to root /
- Using URLSearchParams directly for cleaner submission
- Added netlify-forms-detector page for Netlify to find forms during build
- This matches the behavior of working test forms